### PR TITLE
fix(#8): auto-switch tab when editing nested object field

### DIFF
--- a/ui/.prettierrc.json
+++ b/ui/.prettierrc.json
@@ -2,5 +2,5 @@
   "$schema": "https://json.schemastore.org/prettierrc",
   "semi": false,
   "singleQuote": true,
-  "printWidth": 100
+  "printWidth": 120
 }

--- a/ui/src/utils/index.ts
+++ b/ui/src/utils/index.ts
@@ -10,14 +10,13 @@ import {
   lowerCaseKeys,
   pascalCaseKeys,
   snakeCaseKeys,
-  upperCaseKeys
+  upperCaseKeys,
 } from 'json-case-convertor'
 import { JsonPropertyCaseType } from 'src/enums'
 import type { CodeGenerateResp } from 'src/api/models/code-generate-models'
 import { LANGUAGE_FILE_ICON_COLOR_MAPPING, LANGUAGE_FILE_ICON_NAME_MAPPING } from 'src/constant'
 import type { EditorModel } from 'src/types/code-editor'
 import { Uri } from 'monaco-editor'
-import { nanoid } from 'nanoid'
 
 /**
  * convert json property case
@@ -84,9 +83,7 @@ export function getFileExtension(fileName?: string) {
 export function createEditorModel(codeGenerateResp: CodeGenerateResp): EditorModel {
   const fileName = getFileNameWithoutExtension(codeGenerateResp.fileName)
   const fileExtension = getFileExtension(codeGenerateResp.fileName)
-  // make uri unique to avoid model already exists error
-  const uri = Uri.file(`${fileName}_${nanoid()}.${fileExtension}`)
-  console.log('uri', uri.toString())
+  const uri = Uri.file(`${fileName}.${fileExtension}`)
   return {
     uri,
     fileName: codeGenerateResp.fileName,

--- a/ui/src/views/modules/json-convert/JsonToClass.vue
+++ b/ui/src/views/modules/json-convert/JsonToClass.vue
@@ -53,11 +53,7 @@
           />
         </div>
       </div>
-      <code-editor
-        ref="targetModelEditor"
-        :editor-models="targetModels"
-        @change="handleTargetCodeChange"
-      />
+      <code-editor ref="targetModelEditor" :editor-models="targetModels" @change="handleTargetCodeChange" />
     </div>
     <!--endregion-->
   </div>
@@ -144,8 +140,8 @@ async function handleGenerateTargetCode() {
       return
     }
 
-    targetModels.value.forEach((targetModel) =>
-      targetModelEditor.value?.changeModelCode(targetModel.uri, targetModel.value),
+    targetModels.value.forEach((targetModel, index) =>
+      targetModelEditor.value?.changeModelCode(targetModel.uri, targetModel.value, index),
     )
   } catch (e) {
     $q.notify({

--- a/ui/src/views/modules/json-convert/JsonToEntity.vue
+++ b/ui/src/views/modules/json-convert/JsonToEntity.vue
@@ -53,11 +53,7 @@
           />
         </div>
       </div>
-      <code-editor
-        ref="targetCodeEditor"
-        :editor-models="targetModels"
-        @change="handleTargetCodeChange"
-      />
+      <code-editor ref="targetCodeEditor" :editor-models="targetModels" @change="handleTargetCodeChange" />
     </div>
     <!--endregion-->
   </div>
@@ -145,8 +141,8 @@ async function handleGenerateTargetCode() {
       return
     }
 
-    targetModels.value.forEach((targetModel) =>
-      targetCodeEditor.value?.changeModelCode(targetModel.uri, targetModel.value),
+    targetModels.value.forEach((targetModel, index) =>
+      targetCodeEditor.value?.changeModelCode(targetModel.uri, targetModel.value, index),
     )
   } catch (e) {
     $q.notify({


### PR DESCRIPTION
## Summary

This PR fixes a bug where the right code preview tab does not automatically switch when editing field names in a nested object.